### PR TITLE
convert bin/release to yml format

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
-echo "--- poe-ui build complete"
+cat << EOF
+addons: []
+EOF


### PR DESCRIPTION
According to this: https://devcenter.heroku.com/articles/buildpack-api#bin-release this file should now return a yml.  I just copied what was here without the default_process_types: https://github.com/heroku/heroku-buildpack-nodejs/blob/master/bin/release
