### PR TITLE
Make `bin/release` output valid YAML.

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
-echo "--- poe-ui build complete"
+echo "---"


### PR DESCRIPTION
The Buildpack API (https://devcenter.heroku.com/articles/buildpack-api#bin-release) expects Buildpack release scripts to output YAML, which normally configures platform defaults such as default processes. Recently, Heroku started enforcing this behaviour; Buildpacks that emit non-YAML output now cause build failures.
